### PR TITLE
Fixed typo on 'Previous connections' header

### DIFF
--- a/websocket-history.html
+++ b/websocket-history.html
@@ -56,7 +56,7 @@ Custom property | Description | Default
       @apply --websocket-history-date-time;
     }
     </style>
-    <h3>Prevoius connections</h3>
+    <h3>Previous connections</h3>
     <template is="dom-repeat" items="[[items]]">
       <paper-item>
         <paper-item-body>


### PR DESCRIPTION
Typo found on the 'Previous connections' header - Prevoius -> Previous